### PR TITLE
Make Telegram dedupe aware of release dates

### DIFF
--- a/dedupe.py
+++ b/dedupe.py
@@ -29,10 +29,15 @@ def save_cache(cache: dict) -> None:
 ID_RE = re.compile(r"(NCSC-\d{4}-\d{4})", re.IGNORECASE)
 
 def advisory_key(row: Dict[str, Any]) -> str | None:
-    # 1) voorkeursvelden
+    advisory_id = None
     for field in ("AdvisoryID", "TrackingID", "ID", "CsafID", "Tracking.Id", "tracking.id"):
         if field in row and row[field]:
-            return str(row[field]).strip()
+            advisory_id = str(row[field]).strip().upper()
+            break
+
+    release_date = str(row.get("ReleaseDate", "")).strip()
+    if advisory_id:
+        return f"{advisory_id}|{release_date}" if release_date else advisory_id
     # 2) regex uit Title/Description
     for field in ("Description", "Title", "Naam", "Name"):
         if field in row and row[field]:

--- a/harvest_ncsc.py
+++ b/harvest_ncsc.py
@@ -138,6 +138,7 @@ def normalize_advisory(json_data: dict) -> dict:
         "Severity": severity,
         "Description": title,
         "Link": f"{BASE_ROOT}advisory?id={advisory_id}" if advisory_id else "",
+        "ReleaseDate": "",
     }
 
 
@@ -184,6 +185,7 @@ def main():
                 continue
 
             normalized = normalize_advisory(data)
+            normalized["ReleaseDate"] = release_local_date.isoformat()
             if normalized["AdvisoryID"] or normalized["Description"]:
                 rows.append(normalized)
 
@@ -192,7 +194,7 @@ def main():
             continue
 
     # CSV schrijven
-    fieldnames = ["AdvisoryID", "Version", "Severity", "Description", "Link"]
+    fieldnames = ["AdvisoryID", "Version", "Severity", "Description", "Link", "ReleaseDate"]
 
     with open(out_csv, "w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames)


### PR DESCRIPTION
### Motivation
- Telegram notifications stopped being sent for advisories that were re-published on a later date because dedupe used only the advisory ID as the cache key. 
- The goal is to allow the same advisory to notify again when its release date changes while still suppressing duplicate sends within the same release day.

### Description
- `harvest_ncsc.py`: add a `ReleaseDate` field to the normalized advisory and include it in the CSV `fieldnames` so each harvested row contains the local release date. 
- `harvest_ncsc.py`: populate `normalized["ReleaseDate"] = release_local_date.isoformat()` when the advisory is selected for today. 
- `dedupe.py`: make `advisory_key` date-aware by returning `"{ADVISORY_ID}|{ReleaseDate}"` (uppercasing the ID) when `ReleaseDate` is present, preserving existing fallback regex and hash behaviors. 
- Behaviors unchanged: fallback signature/hash and title/description extraction remain as before so non-NCSC-ID rows still get a stable fallback key.

### Testing
- Ran a focused dedupe check with `python3 - <<'PY' ...` that simulates day1/day2 advisory rows and verifies same-day dedupe suppresses and a different `ReleaseDate` is allowed; the test passed. 
- Ran `python3 notify_ncsc.py` locally to validate notifier behavior; it still skips sending for the existing sample CSV because that CSV was generated before this change and lacks `ReleaseDate`. 
- Attempted a live `python3 harvest_ncsc.py` run to produce a new CSV with `ReleaseDate`, but the run failed here due to an external proxy/network error (`403 Forbidden` via proxy), so a live harvest could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc5231a3148329891445740849d0b9)